### PR TITLE
Adding MSU to DSU list

### DIFF
--- a/csss-site/src/csss/templates/csss/new_header.html
+++ b/csss-site/src/csss/templates/csss/new_header.html
@@ -151,7 +151,8 @@
               Associated Clubs and DSUs
             </div>
 
-            <a target="_blank" class="navbar-item" href="https://www.sfu.ca/computing/wics/" style="text-indent: 20px;">WiCS</a>            
+            <a target="_blank" class="navbar-item" href="https://www.sfu.ca/computing/wics/" style="text-indent: 20px;">WiCS</a>
+            <a target="_blank" class="navbar-item" href="https://sfumsu.github.io/" style="text-indent: 20px;">MSU</a>            
             <a target="_blank" class="navbar-item" href="http://esss.ca/" style="text-indent: 20px;">ESSS</a>            
             <a target="_blank" class="navbar-item" href="https://msess.ca/index.html" style="text-indent: 20px;">Mechs</a>           
             <a target="_blank"  class="navbar-item" href='https://www.facebook.com/ssss.sfu/' style="text-indent: 20px;">SSSS</a>            


### PR DESCRIPTION
All CSSS members are MSU members at one point when completing their MATH requirements. Students completing the joint major offered by the CMPT and MATH departments are members of both the CSSS and MSU throughout their degree. Makes sense to link the MSU website.