### PR TITLE
adding CSS so that embeds in emails dont go past border

### DIFF
--- a/csss-site/src/announcements/static/announcements_static/csss_custom.css
+++ b/csss-site/src/announcements/static/announcements_static/csss_custom.css
@@ -2,3 +2,7 @@
     border:solid 1px grey;
     height: 0px;
 }
+
+.hide_email_embeds {
+    overflow-x: scroll;
+}

--- a/csss-site/src/announcements/templates/announcements/announcements.html
+++ b/csss-site/src/announcements/templates/announcements/announcements.html
@@ -25,11 +25,13 @@
 							{% if announcement.email is None %}
 								{{announcement.manual_announcement.content|safe|linebreaks }}
 							{%  else %}
-								{% if announcement.email.html|safe|length > 0 %}
-									{{announcement.email.html|safe}}
-								{% else %}
-									{{announcement.email.body|safe|linebreaks}}
-								{% endif %}
+								<div class="hide_email_embeds">
+									{% if announcement.email.html|safe|length > 0 %}
+										{{announcement.email.html|safe}}
+									{% else %}
+										{{announcement.email.body|safe|linebreaks}}
+									{% endif %}
+								</div>
 							{%  endif %}
 							</div>
 							{% for attachment in announcement.email.attachments.all %}


### PR DESCRIPTION
fixing this issue by just hiding the extra stuff

![Screenshot from 2021-06-07 19-09-09](https://user-images.githubusercontent.com/14242088/121111528-e174a400-c7c3-11eb-9276-d8e068f3611b.png)
