### PR TITLE
updating how long to sleep

### DIFF
--- a/CI/validate_and_deploy/1_validate/run_jenkins_dockerized_formatting_test.sh
+++ b/CI/validate_and_deploy/1_validate/run_jenkins_dockerized_formatting_test.sh
@@ -19,7 +19,7 @@ docker build --no-cache -t ${docker_test_image_lower_case} \
     --build-arg TEST_RESULT_FILE_NAME=${TEST_RESULT_FILE_NAME} .
 
 docker run -d --name ${DOCKER_TEST_CONTAINER} ${docker_test_image_lower_case}
-sleep 20
+sleep 50
 docker cp ${DOCKER_TEST_CONTAINER}:${CONTAINER_TEST_DIR}/${TEST_RESULT_FILE_NAME} \
     ${LOCALHOST_TEST_DIR}/${TEST_RESULT_FILE_NAME}
 


### PR DESCRIPTION
builds keep showing this error when deploying to staging. upping how long to sleep to see if that helps
```
+ docker run -d --name TEST_WEBSITE_PR-489_pytest test_website_pr-489_website_pytest
376ff22381706dad2ee84479717d0dcab21508b1cfaa4a2b96734bef6d986337
+ sleep 20
+ docker cp TEST_WEBSITE_PR-489_pytest:/usr/src/app/tests/all-unit-tests.xml /var/jenkins_home/workspace/bsite-validate-and-deploy_PR-489/test_results/all-unit-tests.xml
Error: No such container:path: TEST_WEBSITE_PR-489_pytest:/usr/src/app/tests/all-unit-tests.xml
```