### PR TITLE
Frosh 2022 video - hosted on SFU Vault

### DIFF
--- a/csss-site/src/events/frosh/static/frosh_static/2022/css/frosh2022.css
+++ b/csss-site/src/events/frosh/static/frosh_static/2022/css/frosh2022.css
@@ -1,3 +1,9 @@
+
+video {
+  width: 100% !important;
+  height: auto !important;
+}
+
 .stack {
   display: flex;
   flex-direction: column;

--- a/csss-site/src/events/frosh/static/frosh_static/2022/css/frosh2022.css
+++ b/csss-site/src/events/frosh/static/frosh_static/2022/css/frosh2022.css
@@ -1,7 +1,11 @@
 
-video {
-  width: 100% !important;
-  height: auto !important;
+#video-frame {
+  width: max(80%, 300px);
+}
+
+.video {
+  aspect-ratio: 16 / 9;
+  width: 100%;
 }
 
 .stack {
@@ -184,7 +188,8 @@ padding-bottom: 56.25%; /* 16:9 */
 padding-top: 25px;
 height: 0;
 }
-.responsive-frame iframe {
+.responsive-frame iframe,
+.video-frame iframe {
 position: absolute;
 top: 0;
 left: 0;

--- a/csss-site/src/events/frosh/templates/frosh/2022/frosh.html
+++ b/csss-site/src/events/frosh/templates/frosh/2022/frosh.html
@@ -48,11 +48,8 @@
     <p>Something sweet is coming!</p>
     <img src="{% static 'frosh_static/2022/images/frosh2022_logo_1000x1000.png' %}" alt="Frosh 2022 Logo" id="logo" class="center"/> 
 </section>
-<div class="center">
-    <video controls preload="metadata">
-        <!-- Need to use SFU Vault because of GitHub 100 MB file size limit. This link currently points to a file hosted in Oliver's (Liversticks) SFU account. -->
-        <source src="http://vault.sfu.ca/index.php/s/cRoboB5qowvz6uk/download" type="video/mp4"/>
-    </video>
+<div class="center" id="video-frame">
+    <iframe class="video" src="https://www.youtube.com/embed/kCjToAoN0fA" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 </div>
 <div class="center">
   <ul class="signup-list">

--- a/csss-site/src/events/frosh/templates/frosh/2022/frosh.html
+++ b/csss-site/src/events/frosh/templates/frosh/2022/frosh.html
@@ -49,7 +49,7 @@
     <img src="{% static 'frosh_static/2022/images/frosh2022_logo_1000x1000.png' %}" alt="Frosh 2022 Logo" id="logo" class="center"/> 
 </section>
 <div class="center" id="video-frame">
-    <iframe class="video" src="https://www.youtube.com/embed/kCjToAoN0fA" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+    <iframe class="video" src="https://www.youtube.com/embed/kCjToAoN0fA" title="YouTube video player" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 </div>
 <div class="center">
   <ul class="signup-list">

--- a/csss-site/src/events/frosh/templates/frosh/2022/frosh.html
+++ b/csss-site/src/events/frosh/templates/frosh/2022/frosh.html
@@ -49,6 +49,12 @@
     <img src="{% static 'frosh_static/2022/images/frosh2022_logo_1000x1000.png' %}" alt="Frosh 2022 Logo" id="logo" class="center"/> 
 </section>
 <div class="center">
+    <video controls preload="metadata">
+        <!-- Need to use SFU Vault because of GitHub 100 MB file size limit. This link currently points to a file hosted in Oliver's (Liversticks) SFU account. -->
+        <source src="http://vault.sfu.ca/index.php/s/cRoboB5qowvz6uk/download" type="video/mp4"/>
+    </video>
+</div>
+<div class="center">
   <ul class="signup-list">
   
     <li>  


### PR DESCRIPTION
Due to GitHub 100 MB file size limit, the video is hosted on a SFU Vault account belonging to Oliver (Liversticks). The link is publicly accessible.