### PR TITLE
enable w3_committee team to exist in github

### DIFF
--- a/csss-site/src/resource_management/views/resource_apis/github/github_api.py
+++ b/csss-site/src/resource_management/views/resource_apis/github/github_api.py
@@ -266,7 +266,9 @@ class GitHubAPI:
         """
         if not self.connection_successful:
             return False, self.error_message
-
+        elif team_name == "w3_committee":
+            return False, "cannot remove w3_committee"
+        
         successful = False
         team = None
         while not successful:
@@ -312,6 +314,8 @@ class GitHubAPI:
         team_name -- the name of the team to delete
         """
         if not self.connection_successful:
+            return
+        elif team_name == "w3_committee":
             return
         successful = False
         while not successful:


### PR DESCRIPTION
this is a hack so that the website doesn’t remove the w3 committee from the github organization. The team automation will be updated soon & this implementation will be deprecated.