### PR TITLE
Adding a link to the 2024 tech fair site

### DIFF
--- a/csss-site/src/events/tech_fair/templates/tech_fair/timeline.html
+++ b/csss-site/src/events/tech_fair/templates/tech_fair/timeline.html
@@ -27,11 +27,11 @@
                     <span>Tech Fair 2022</span>
                 </a>
 
-                <a href="{{ URL_ROOT }}events/tech_fair/2023" class="nav-button nav-pink">
+                <a href="{{ URL_ROOT }}events/tech_fair/2023" class="nav-button nav-black">
                     <span>Tech Fair 2023</span>
                 </a>
 
-                <a title="coming soon!" href="https://new.sfucsss.org/tech_fair/2024/" class="nav-button nav-black">
+                <a title="coming soon!" href="https://new.sfucsss.org/tech_fair/2024/" class="nav-button nav-pink">
                     <span>Tech Fair 2024 <br> (VERY SOON!)</span>
                 </a>
             </div>

--- a/csss-site/src/events/tech_fair/templates/tech_fair/timeline.html
+++ b/csss-site/src/events/tech_fair/templates/tech_fair/timeline.html
@@ -27,12 +27,12 @@
                     <span>Tech Fair 2022</span>
                 </a>
 
-                <a href="{{ URL_ROOT }}events/tech_fair/2023" class="nav-button nav-black">
+                <a href="{{ URL_ROOT }}events/tech_fair/2023" class="nav-button nav-pink">
                     <span>Tech Fair 2023</span>
                 </a>
 
-                <a title="coming soon!" href="#" class="nav-button" style="color: #999">
-                    <span><em>(coming soon)</em> <br> Tech Fair 2024</span>
+                <a title="coming soon!" href="https://new.sfucsss.org/tech_fair/2024/" class="nav-button nav-black">
+                    <span>Tech Fair 2024 <br> (VERY SOON!)</span>
                 </a>
             </div>
         </div>


### PR DESCRIPTION
As requested by our favourite tech fair host, adding a link to the new tech fair site! Only temporary, but definitely important \:)

Next PR will be to update the new site to link back to the homepage as well.