### PR TITLE
freezing setuptools version because of django_allauth

### DIFF
--- a/CI/validate_and_deploy/2_deploy/2_deploy_staging_changes.sh
+++ b/CI/validate_and_deploy/2_deploy/2_deploy_staging_changes.sh
@@ -24,6 +24,7 @@ function setup_master_virtual_env(){
   rm -fr "${BASE_DIR}/envCSSS_master"
   python3 -m virtualenv envCSSS_master
   . "${BASE_DIR}/envCSSS_master/bin/activate"
+  python3 -m pip install setuptools==68.2.2 --no-cache-dir
   python3 -m pip install -r "${BASE_DIR}/csss-site/requirements.txt" --no-cache-dir
 
 
@@ -48,6 +49,7 @@ function switch_to_pr_branch(){
   cd "${BASE_DIR}"
   python3 -m virtualenv envCSSS
   . "${BASE_DIR}/envCSSS/bin/activate"
+  python3 -m pip install setuptools==68.2.2 --no-cache-dir
   python3 -m pip install -r "${BASE_DIR}/csss-site/requirements.txt" --no-cache-dir
 }
 


### PR DESCRIPTION
need to specifically set the setuptools version as it's automatically set to version 7.0.0 now which causes an issue with django_allauth
```
Collecting django-allauth==0.39.1 (from -r /home/csss/PR-655/csss-site/requirements.txt (line 25))
  Downloading django-allauth-0.39.1.tar.gz (534 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 534.7/534.7 kB 143.1 MB/s eta 0:00:00
  Preparing metadata (setup.py): started
  Preparing metadata (setup.py): finished with status 'error'
  error: subprocess-exited-with-error
  
  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [6 lines of output]
      Traceback (most recent call last):
        File "<string>", line 2, in <module>
        File "<pip-setuptools-caller>", line 34, in <module>
        File "/tmp/pip-install-7ml4sbuq/django-allauth_6c8eb0e39969421ea4bb8b2893c6e1bf/setup.py", line 7, in <module>
          from setuptools import convert_path, find_packages, setup
      ImportError: cannot import name 'convert_path' from 'setuptools' (/home/csss/PR-655/envCSSS_master/lib/python3.8/site-packages/setuptools/__init__.py)
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> See above for output.

note: This is an issue with the package mentioned above, not pip.
hint: See above for details.
```